### PR TITLE
Improvements to jvnet-parent

### DIFF
--- a/jvnet-parent/pom.xml
+++ b/jvnet-parent/pom.xml
@@ -12,35 +12,35 @@
   ~ See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-	<groupId>net.java</groupId>
-	<artifactId>jvnet-parent</artifactId>
-	<version>5-SNAPSHOT</version>
-	<packaging>pom</packaging>
+  <groupId>net.java</groupId>
+  <artifactId>jvnet-parent</artifactId>
+  <version>5-SNAPSHOT</version>
+  <packaging>pom</packaging>
 
-	<name>Java.net Parent</name>
-	<url>http://java.net/</url>
-	<description>Java.net - The Source for Java Technology Collaboration</description>
+  <name>Java.net Parent</name>
+  <url>http://java.net/</url>
+  <description>Java.net - The Source for Java Technology Collaboration</description>
 
-	<scm>
-		<connection>scm:git:git@github.com:sonatype/jvnet-parent.git</connection>
-		<developerConnection>scm:git:git@github.com:sonatype/jvnet-parent.git</developerConnection>
-		<url>https://github.com/sonatype/jvnet-parent</url>
-	</scm>
+  <scm>
+    <connection>scm:git:git@github.com:sonatype/jvnet-parent.git</connection>
+    <developerConnection>scm:git:git@github.com:sonatype/jvnet-parent.git</developerConnection>
+    <url>https://github.com/sonatype/jvnet-parent</url>
+  </scm>
 
-	<distributionManagement>
-		<snapshotRepository>
-			<id>jvnet-nexus-snapshots</id>
-			<name>Java.net Nexus Snapshots Repository</name>
-			<url>${jvnetDistMgmtSnapshotsUrl}</url>
-		</snapshotRepository>
-		<repository>
-			<id>jvnet-nexus-staging</id>
-			<name>Java.net Nexus Staging Repository</name>
-			<url>https://maven.java.net/service/local/staging/deploy/maven2/</url>
-		</repository>
-	</distributionManagement>
+  <distributionManagement>
+    <snapshotRepository>
+      <id>jvnet-nexus-snapshots</id>
+      <name>Java.net Nexus Snapshots Repository</name>
+      <url>${jvnetDistMgmtSnapshotsUrl}</url>
+    </snapshotRepository>
+    <repository>
+      <id>jvnet-nexus-staging</id>
+      <name>Java.net Nexus Staging Repository</name>
+      <url>https://maven.java.net/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
 
   <!--
     Configure jvnet-nexus-releases repository by default.
@@ -71,64 +71,64 @@
       </snapshots>
     </pluginRepository>
   </pluginRepositories>
-  
-	<build>
-		<pluginManagement>
-			<plugins>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-release-plugin</artifactId>
-					<configuration>
-						<mavenExecutorId>forked-path</mavenExecutorId>
-						<useReleaseProfile>false</useReleaseProfile>
-						<arguments>-Pjvnet-release ${release.arguments}</arguments>
-					</configuration>
-				</plugin>
-			</plugins>
-		</pluginManagement>
-	</build>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<jvnetDistMgmtSnapshotsUrl>https://maven.java.net/content/repositories/snapshots/</jvnetDistMgmtSnapshotsUrl>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-release-plugin</artifactId>
+          <configuration>
+            <mavenExecutorId>forked-path</mavenExecutorId>
+            <useReleaseProfile>false</useReleaseProfile>
+            <arguments>-Pjvnet-release ${release.arguments}</arguments>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <jvnetDistMgmtSnapshotsUrl>https://maven.java.net/content/repositories/snapshots/</jvnetDistMgmtSnapshotsUrl>
     <!-- 
       intialize release.arguments to empty, otherwise if not defined
       it can fail the release plugin
     -->
     <release.arguments></release.arguments>
-	</properties>
+  </properties>
 
-	<profiles>
-		<profile>
-			<id>jvnet-release</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-source-plugin</artifactId>
+  <profiles>
+    <profile>
+      <id>jvnet-release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
             <version>2.1</version>
-						<executions>
-							<execution>
-								<id>attach-sources</id>
-								<goals>
-									<goal>jar-no-fork</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-javadoc-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
             <version>2.8</version>
-						<executions>
-							<execution>
-								<id>attach-javadocs</id>
-								<goals>
-									<goal>jar</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-enforcer-plugin</artifactId>
@@ -151,24 +151,24 @@
               </execution>
             </executions>
           </plugin>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-gpg-plugin</artifactId>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
             <version>1.1</version>
-						<executions>
-							<execution>
-								<id>sign-artifacts</id>
-								<phase>verify</phase>
-								<goals>
-									<goal>sign</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-		<profile>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>snapshots</id>
       <repositories>
         <repository>


### PR DESCRIPTION
Add jvnet-nexus-releases to default configuration. Default releases.arguments to empty in order not to fail the release-plugin when not defined. Set version for all plugins defined (gpg, javadoc, source, enforcer). Fix indentation using tab=2. Changed copyright year.
